### PR TITLE
Set a default value for session max age

### DIFF
--- a/lib/express-config.js
+++ b/lib/express-config.js
@@ -254,6 +254,7 @@ module.exports.defaultOptions = {
 	sessionName: 'Session',
 	session: {
 		cookie: {
+			maxAge: 1000 * 60 * 60 * 24 * 7, // One week
 			sameSite: 'strict',
 			secure: (process.env.NODE_ENV === 'production')
 		},

--- a/test/unit/lib/express-config.test.js
+++ b/test/unit/lib/express-config.test.js
@@ -768,6 +768,7 @@ describe('lib/express-config', () => {
 			it('contains default values for Express Session', () => {
 				assert.deepEqual(configureExpress.defaultOptions.session, {
 					cookie: {
+						maxAge: 604800000,
 						sameSite: 'strict',
 						secure: false
 					},


### PR DESCRIPTION
The default meant that sessions only lasted for the duration of the
browser session, which causes issues if the browser is quit. Also on
mobile you'd be logged out frequently.